### PR TITLE
Make nqueens.c C++ compatible.

### DIFF
--- a/nqueens.c
+++ b/nqueens.c
@@ -68,7 +68,7 @@ void put_queen(NQueens *nqueens, int *positions, int target_row) {
 
 // Solve the n queens puzzle and print the number of solutions
 void solve(NQueens *nqueens) {
-    int *positions = malloc(nqueens->size * sizeof(int));
+    int *positions = (int*)malloc(nqueens->size * sizeof(int));
     memset(positions, ~0, nqueens->size * sizeof(int));
     put_queen(nqueens, positions, 0);
     printf("Found %d solutions\n", nqueens->solutions);


### PR DESCRIPTION
In C++, the return type of malloc() must be cast to the lvalue type:

    $ clang++ -xc++  nqueens.c
    nqueens.c:76:8: error: cannot initialize a variable of type 'int *' with an rvalue of type 'void *'
      int *positions = malloc(nqueens->size * sizeof(int));
           ^           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    1 error generated.

This does not affect the behaviour of the program when compiled with C compiler.